### PR TITLE
build(gem): support Rails 6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+gemfiles/*.lock
+

--- a/active_job-disable.gemspec
+++ b/active_job-disable.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activejob', '>= 5.0', '< 6'
+  spec.add_dependency 'activejob', '>= 5.0'
   spec.add_development_dependency 'rake', '~> 12.3.2'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'actionmailer', '>= 5.0', '< 6'

--- a/gemfiles/README.md
+++ b/gemfiles/README.md
@@ -1,0 +1,5 @@
+# Switch the Gemfile used by Bundler
+
+See `BUNDLE_GEMFILE` section
+
+<https://bundler.io/v2.2/man/bundle-config.1.html#LIST-OF-AVAILABLE-KEYS>

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "activejob", '~> 6.0.0'
+gem "actionmailer", '~> 6.0.0'


### PR DESCRIPTION
Relates to #3

# How has this been tested?

```sh
export BUNDLE_GEMFILE=gemfiles/rails_6.0.gemfile
bundle && bundle exec rake
```

Out of scope:

- CircleCI [Matrix jobs](https://circleci.com/blog/circleci-matrix-jobs/)
- Testing Rails 6.2
